### PR TITLE
Empty transform matrix causing reference errors

### DIFF
--- a/src/components/hoverable-visuals.js
+++ b/src/components/hoverable-visuals.js
@@ -1,7 +1,17 @@
 import { showHoverEffect } from "../utils/permissions-utils";
 
-const interactorOneTransform = [];
-const interactorTwoTransform = [];
+const interactorOneTransform = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1
+];
+const interactorTwoTransform = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1
+];
 
 export const validMaterials = ["MeshStandardMaterial", "MeshBasicMaterial", "MeshPhongMaterial"];
 /**


### PR DESCRIPTION
A recent update to Chrome (128) appears to have exposed a bug, as described in this [Discord post](https://discord.com/channels/498741086295031808/1158476691384062012/1275019411564265483).

I traced at least one cause (there may be more) to the use of a temporary array in the *hoverable-visuals* component. A threejs matrix is copied into the array and then the position elements are read and ultimately submitted as uniforms to the WebGL shader. However, if `interactorOne` or `interactorTwo` are not active, the matrix is not written and the required elements are never initialized. Seeding the array with a unit matrix fixes the problem.

It's not clear why this has only just started causing a runtime issue. Perhaps Chrome used to interpret `undefined` as zero instead of throwing a TypeError?
