### PR TITLE
Hubs Foundation docker registry update

### DIFF
--- a/.github/workflows/hubs-RetPageOrigin.yml
+++ b/.github/workflows/hubs-RetPageOrigin.yml
@@ -4,16 +4,19 @@ on:
     branches:
     paths-ignore: ["README.md"]
   workflow_dispatch:
-    inputs:
-      smokeroom-choice:
-        type: choice
-        description: Select smoke instance
-        options:
-          - "smoke01"
-          - "smoke02"
-          - "smoke03"
-          - "smoke04"
-          - "smoke05"
+    # Smoke instances aren't currently set up as of 2024-09-08
+    # so commenting out the smoke stuff for now.
+    # inputs:
+    #   smokeroom-choice:
+    #     type: choice
+    #     description: Select smoke instance
+    #     options:
+    #       - "smoke01"
+    #       - "smoke02"
+    #       - "smoke03"
+    #       - "smoke04"
+    #       - "smoke05"
+
 jobs:
   turkeyGitops:
     uses: Hubs-Foundation/hubs-ops/.github/workflows/turkeyGitops.yml@master

--- a/.github/workflows/hubs-RetPageOrigin.yml
+++ b/.github/workflows/hubs-RetPageOrigin.yml
@@ -18,7 +18,7 @@ jobs:
   turkeyGitops:
     uses: Hubs-Foundation/hubs-ops/.github/workflows/turkeyGitops.yml@master
     with:
-      registry: mozillareality
+      registry: hubsfoundation
       dockerfile: RetPageOriginDockerfile
       k8s_deployment: hubs
       k8s_deployment_container: hubs


### PR DESCRIPTION
Use the Hubs Foundation's docker hub repository and comment out anything that the Hubs Foundation doesn't have infrastructure for.