### PR TITLE
Fix bug: Spacebar Menu Scale and Rotate Buttons Do Nothing When Interacted With

### DIFF
--- a/src/components/hoverable-visuals.js
+++ b/src/components/hoverable-visuals.js
@@ -1,19 +1,7 @@
 import { showHoverEffect } from "../utils/permissions-utils";
 
-// prettier-ignore
-const interactorOneTransform = [
-  1, 0, 0, 0,
-  0, 1, 0, 0,
-  0, 0, 1, 0,
-  0, 0, 0, 1
-];
-// prettier-ignore
-const interactorTwoTransform = [
-  1, 0, 0, 0,
-  0, 1, 0, 0,
-  0, 0, 1, 0,
-  0, 0, 0, 1
-];
+const interactorOneTransform = [];
+const interactorTwoTransform = [];
 
 export const validMaterials = ["MeshStandardMaterial", "MeshBasicMaterial", "MeshPhongMaterial"];
 /**


### PR DESCRIPTION
Revert 699187a537b30d2b67dbe059d44311ceaebcefa0 and part of 1567f224c1db251e9540626211e68b4dea06b32e

Fixes #6496

Chromium version 128 introduced a bug in Hubs that was fixed by the #6495 PR but #6495 seems to have introduced the bug detailed in issue #6496 for all browsers. Now Chromium has fixed an issue on their end as detailed here: https://issues.chromium.org/issues/361823993 which should fix the original bug that PR #6495 addressed in Hubs, which allows us to revert the fix on the Hubs side (PR #6495) and so fix the #6496 bug.  However, this doesn't do anything for the potentially deeper issues in the system that were possibly exposed with PR #6495.