### PR TITLE
Fixes #6496 - scale & rotate buttons

### DIFF
--- a/src/systems/hold-system.js
+++ b/src/systems/hold-system.js
@@ -13,7 +13,7 @@ import {
   HeldHandLeft,
   AEntity,
   Networked,
-  Rigidbody
+  Rigidbody, Deletable, MediaLoader
 } from "../bit-components";
 import { canMove } from "../utils/permissions-utils";
 import { canMove as canMoveEntity } from "../utils/bit-permissions-utils";
@@ -81,7 +81,7 @@ export function isAEntityPinned(world, eid) {
 function grab(world, userinput, queryHovered, held, grabPath) {
   const hovered = queryHovered(world)[0];
 
-  const interactable = findAncestorWithComponents(world, [Holdable, Rigidbody], hovered);
+  const interactable = findAncestorWithComponents(world, [Deletable, MediaLoader, Holdable, Rigidbody], hovered);
   const target = interactable ? interactable : hovered;
   const isEntityPinned = isPinned(target) || isAEntityPinned(world, target);
 


### PR DESCRIPTION
Bisecting showed the PR that introduced the bug was https://github.com/Hubs-Foundation/hubs/pull/6487  Among many changes there, findAncestorWithComponents() needed be called with Rigidbody.  Holdable was retained and Deletable and MediaLoader were left out.  

If it was a simple oversight, this PR should be a complete fix.  If there were reasons to drop Deletable and MediaLoader, we'll need to do more work.