### PR TITLE
Partially fix rotating and scaling via the spacebar menu buttons

### DIFF
--- a/src/bit-systems/object-menu.ts
+++ b/src/bit-systems/object-menu.ts
@@ -105,7 +105,7 @@ function startRotation(world: HubsWorld, menuEid: EntityID, targetEid: EntityID)
   }
   const transformSystem = APP.scene!.systems["transform-selected-object"];
   const physicsSystem = AFRAME.scenes[0].systems["hubs-systems"].physicsSystem;
-  physicsSystem.updateRigidBody(Rigidbody.bodyId[targetEid], { type: "kinematic" });
+  physicsSystem.updateRigidBody(targetEid, { type: "kinematic" });
   const rightCursorEid = anyEntityWith(world, RemoteRight)!;
   transformSystem.startTransform(world.eid2obj.get(targetEid)!, world.eid2obj.get(rightCursorEid)!, {
     mode: TRANSFORM_MODE.CURSOR
@@ -137,7 +137,7 @@ function startScaling(world: HubsWorld, menuEid: EntityID, targetEid: EntityID) 
   // TODO: Remove the dependency with AFRAME
   const transformSystem = (AFRAME as any).scenes[0].systems["transform-selected-object"];
   const physicsSystem = AFRAME.scenes[0].systems["hubs-systems"].physicsSystem;
-  physicsSystem.updateRigidBody(Rigidbody.bodyId[targetEid], { type: "kinematic" });
+  physicsSystem.updateRigidBody(targetEid, { type: "kinematic" });
   const rightCursorEid = anyEntityWith(world, RemoteRight)!;
   scalingHandler = new ScalingHandler(world.eid2obj.get(targetEid), transformSystem);
   scalingHandler!.objectToScale = world.eid2obj.get(targetEid);

--- a/src/components/transform-object-button.js
+++ b/src/components/transform-object-button.js
@@ -55,7 +55,7 @@ AFRAME.registerComponent("transform-button", {
       if (!NAF.utils.isMine(this.targetEl) && !NAF.utils.takeOwnership(this.targetEl)) {
         return;
       }
-      if (this.targetEl.body) {
+      if (this.targetEl.hasAttribute("body-helper")) {
         this.targetEl.setAttribute("body-helper", AMMO_BODY_ATTRIBUTES);
       }
       this.transformSystem = this.transformSystem || AFRAME.scenes[0].systems["transform-selected-object"];

--- a/src/systems/hold-system.js
+++ b/src/systems/hold-system.js
@@ -13,13 +13,14 @@ import {
   HeldHandLeft,
   AEntity,
   Networked,
-  Rigidbody
+  Rigidbody,
+  HoldableButton
 } from "../bit-components";
 import { canMove } from "../utils/permissions-utils";
 import { canMove as canMoveEntity } from "../utils/bit-permissions-utils";
 import { isPinned } from "../bit-systems/networking";
 import { takeOwnership } from "../utils/take-ownership";
-import { findAncestorWithComponents } from "../utils/bit-utils";
+import { findAncestorWithComponents, findAncestorWithComponent } from "../utils/bit-utils";
 
 const GRAB_REMOTE_RIGHT = paths.actions.cursor.right.grab;
 const DROP_REMOTE_RIGHT = paths.actions.cursor.right.drop;
@@ -81,8 +82,10 @@ export function isAEntityPinned(world, eid) {
 function grab(world, userinput, queryHovered, held, grabPath) {
   const hovered = queryHovered(world)[0];
 
+  const holdablebutton = findAncestorWithComponent(world, HoldableButton, hovered);
   const interactable = findAncestorWithComponents(world, [Holdable, Rigidbody], hovered);
   const target = interactable ? interactable : hovered;
+  const holdtarget = holdablebutton ? holdablebutton : target;
   const isEntityPinned = isPinned(target) || isAEntityPinned(world, target);
 
   if (
@@ -94,8 +97,8 @@ function grab(world, userinput, queryHovered, held, grabPath) {
     if (hasComponent(world, Networked, target)) {
       takeOwnership(world, target);
     }
-    addComponent(world, held, target);
-    addComponent(world, Held, target);
+    addComponent(world, held, holdtarget);
+    addComponent(world, Held, holdtarget);
   }
 }
 


### PR DESCRIPTION
Pass the eid of the object to the updateRigidBody function instead of the bodyId for the bitECS versions of rotating and scaling via the spacebar menu buttons.  updateRigidBody attempts to get the bodyId from the eid, so doing it beforehand prevented the body from being found.

Update the check for whether the aframe object is a rigid body by checking for the "body-helper" attribute.  This allows the update of the object to be kinematic to go through when the spacebar rotate/scale buttons are engaged.

Check if what is being hovered over when grabbing something is a HoldableButton and if it is, then use that as the hold target instead of the 3D object.  This causes the grab to interact with the button and start the transform instead of just moving the object.

Note: if you attempt to throw the object in the aframe loader and then try to rotate it again with the button, the physics system will fight it for some reason and prevent the rotation.  Clicking on the object a couple times will cause the physics system to release it, but the reason for this behavior is unknown; it could possibly be related to ownership not being set properly or the rigid body not being updated properly.  This behavior was fixed on the bitECS side by passing the eid instead of the bodyId to the updateRigidBody function, but activating the rigid body update on the aframe side (mentioned above) didn't fix it for the aframe side.