### PR TITLE
Fixes layout bug in chat sidebar introduced by PR #6511

### DIFF
--- a/src/react-components/room/ChatSidebar.scss
+++ b/src/react-components/room/ChatSidebar.scss
@@ -51,7 +51,7 @@
   flex-direction: row;
   justify-content: start;
   font-size: theme.$font-size-md;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   line-height: 1.25;
 
   img,


### PR DESCRIPTION
Sidebar chat text with hard-to-break lines, such as URLs, extends outside the bubble. This forces better line breaking.