### PR TITLE
Exited room screen: email link includes name of room

### DIFF
--- a/src/react-components/room/ExitedRoomScreen.js
+++ b/src/react-components/room/ExitedRoomScreen.js
@@ -90,7 +90,7 @@ export function ExitedRoomScreen({ reason, showTerms, termsUrl, showSourceLink }
           <FormattedMessage
             id="exited-room-screen.contact-us"
             defaultMessage="If you have questions, contact us at {contactEmail}."
-            values={{ contactEmail: <a href={`mailto:${contactEmail}`}>{contactEmail}</a> }}
+            values={{ contactEmail: <a href={encodeURI(`mailto:${contactEmail}?subject=Room closed: ${document.title}`)}>{contactEmail}</a> }}
           />
         </p>
         {showSourceLink && (


### PR DESCRIPTION
When a room is closed, a screen is displayed that contains a link for the contact email. This PR adds a default subject containing the name of the room, so the administrator can tell what room the user is communicating about.
