### PR TITLE
Force the repository name to be lowercase in the custom docker workflow

### DIFF
--- a/.github/workflows/custom-docker-build-push.yml
+++ b/.github/workflows/custom-docker-build-push.yml
@@ -71,9 +71,9 @@ jobs:
           echo ::add-mask::$PASSWORD
           echo Registry_Password=$PASSWORD >> $GITHUB_ENV
 
-      - name: Add the repository name as an env variable
+      - name: Add the repository name as an env variable # Lowercase is forced to prevent errors.
         run: |
-          echo "repo_name=${GITHUB_REPOSITORY#*/}" >> "$GITHUB_ENV"
+          echo "repo_name=${GITHUB_REPOSITORY#*/}" | tr "[:upper:]" "[:lower:]" >> "$GITHUB_ENV"
 
       # Code
       - name: Checkout repository


### PR DESCRIPTION
## What?
Converts the repository name to lowercase before storing it as an environment variable for use when connecting to the docker repository.

## Why?
Some (or possibly all?) container registries don't allow their repository names to be capitalized, but the workflow gets the docker repository name from the GitHub repository name (which is allowed to be capitalized), so if the GitHub repository name is capitalized, this can prevent the workflow from working.

## How to test

Repository name with no uppercase letters:
1. Push the changes to a branch on your personal GitHub repository.
2. Run the `custom-docker-build-push` action/workflow on that branch. ([Workflow docs](https://github.com/Hubs-Foundation/hubs/wiki/GitHub-Workflows))

Repository name with uppercase letters:
1. Basically the same process as above, but use this pull request from the Spoke repository (which is capitalized): https://github.com/Hubs-Foundation/Spoke/pull/1305

