### PR TITLE
Fix incorrect chat grouping of Discord messages

### DIFF
--- a/src/react-components/room/contexts/ChatContext.tsx
+++ b/src/react-components/room/contexts/ChatContext.tsx
@@ -30,7 +30,7 @@ function shouldCreateNewMessageGroup(messageGroups: NewMessageT[], newMessage: N
 
   const lastMessageGroup = messageGroups[messageGroups.length - 1];
 
-  if (lastMessageGroup.senderSessionId !== newMessage.sessionId) {
+  if (lastMessageGroup.senderSessionId !== newMessage.sessionId || lastMessageGroup.sender !== newMessage.name) {
     return true;
   }
   if (lastMessageGroup.type !== newMessage.type) {


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Prevents Discord messages from different users that are sent within a minute of each other from being grouped together under the first user that sends a message by also checking the name given for the sender instead of just the sender's id.  This mostly ensures that all chat messages are attributed to the correct user.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
Users in Hubs can have the same name so the chat messages are grouped by a sender id, but because all the messages from Discord come through the Discord bot, the sender id is the same for all of them regardless of who sent them in Discord.

## Examples
<!-- If applicable, give examples of your changes, screenshots, videos, etc. -->
Not easy to get and the change is very small, easily seen, and is described in other parts of this pull request.

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Redeploy your instance using a Hubs Client image generated from this PR (e.g. `ghcr.io/exairnous/hubs:fix-discord-bot-mixing-chat-messages-34`).
2. Follow the instructions for hacking on the bot locally that are listed in PR https://github.com/Hubs-Foundation/hubs-discord-bot/pull/146 and set up the Hubs bot against your Community Edition instance.
3. Create a room with the Hubs bot with `!hubs create`.
4. Join the Hubs room that has been bridged to Discord.
5. In your Discord server, in the channel you've set the bot up in, send a Discord message and have someone else send a Discord message immediately after.
6. See that they are listed as from the correct people in the chat panel (previously they would both be listed under the name of the person who first sent the message).

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
This is an implementation detail and doesn't need to be documented.  It is also immediately obvious.

## Limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
This will still group messages improperly if the Discord users have the same display name in the Discord server but preventing that would likely require much more extensive and broad reaching changes (probably in reticulum and the Hubs Discord bot repository as well) and it would do little to reduce confusion.

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded -->
None.

## Open questions
<!-- List any questions you have -->
None.

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
None.