### PR TITLE
Install missing phantomjs for arm64 build support

### DIFF
--- a/RetPageOriginDockerfile
+++ b/RetPageOriginDockerfile
@@ -3,6 +3,8 @@
 # the result container should serve reticulum as "hubs_page_origin" and "admin_page_origin" on (path) "/hubs/pages"
 ###
 from node:16.16 as builder
+env QT_QPA_PLATFORM offscreen
+run apt update && apt -y install phantomjs
 run mkdir -p /hubs/admin/ && cd /hubs
 copy package.json ./
 copy package-lock.json ./


### PR DESCRIPTION
## What?

Installs PhantomJS using apt rather than with npm.

## Why?

npm binaries are not available for arm64 so this change enables us to build for arm64 as well as amd64 

## Examples

N/A

## How to test

Build container as usual for amd64 and deploy to a test instance of Hubs

## Documentation of functionality

As above

## Limitations

None known (tested with amd64 and arm64)

## Alternatives considered

N/A

## Open questions

N/A

## Additional details or related context

N/A
