### PR TITLE
bump docker container to nodejs 22 and remove phantomjs 

### DIFF
--- a/RetPageOriginDockerfile
+++ b/RetPageOriginDockerfile
@@ -2,9 +2,7 @@
 # this dockerfile produces image/container that serves customly packaged hubs and admin static files
 # the result container should serve reticulum as "hubs_page_origin" and "admin_page_origin" on (path) "/hubs/pages"
 ###
-from node:16.16 as builder
-env QT_QPA_PLATFORM offscreen
-run apt update && apt -y install phantomjs
+from node:22 as builder
 run mkdir -p /hubs/admin/ && cd /hubs
 copy package.json ./
 copy package-lock.json ./


### PR DESCRIPTION
## What?
This tests upgrading the docker container to a newer Debian without phantomjs. PhantomJS appears to be a vestigial dependency that isn't used by anything in the repository, nor as a runtime `dependency` in any transitive sub-dependencies.

## Why?
This is to enable the modernization of packages and infrastructure in #6549 more incrementally.

## How to test
Docker image builds and deploys.

## Documentation of functionality
Docker file is self-documenting, and this should be a seamless transition.

## Alternatives considered
We could update to 'just' nodes 20 and still install phantomjs, but I think it's better to relieve the phantomjs constraint (archived and abandoned for over 5 years now).

## Additional details or related context
in support of #6549 
